### PR TITLE
fix: 修复 elasticsearch 需要密码认证时，正确配置了认证信息，却无法使用问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 /vendor
+.idea/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Now we can add the `channel` of `channels` in `config/logging.php` file.
 
 ```php
 'channels' => [
+	.
+	.
+	.
     'elastic' => [
         'driver' => 'custom',
         'via' => Betterde\Logger\ElasticsearchLogger::class,
@@ -36,7 +39,7 @@ protected $middleware = [
     \App\Http\Middleware\TrimStrings::class,
     \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
     \App\Http\Middleware\TrustProxies::class,
-    \Betterde\Logger\Http\Middleware\BulkCollectionLog::class
+    \Betterde\Logger\Http\Middleware\BulkCollectionLog::class,
 ];
 ```
 
@@ -49,6 +52,7 @@ ELASTICSEARCH_PORT=9200
 ELASTICSEARCH_SCHEME=http
 ELASTICSEARCH_USER=
 ELASTICSEARCH_PASS=
+ELASTICSEARCH_LOG_INDEX_PREFIX=laravel
 ```
 
 Finally, I hope this is helpful.

--- a/config/logger.php
+++ b/config/logger.php
@@ -4,7 +4,7 @@ return [
     /*
      * Enable sending log of batch
      */
-    'batch' => false,
+    'batch' => true,
 
     /*
      * Enable queue sending log
@@ -48,7 +48,7 @@ return [
      * Handler options
      */
     'options' => [
-        'index' => 'monolog', // Elastic index name
+        'index' => 'monolog_'.env('ELASTICSEARCH_LOG_INDEX_PREFIX','cblink1_0').'_'.env('APP_ENV'), // Elastic index name
         'type' => '_doc',    // Elastic document type
         'ignore_error' => false,     // Suppress Elasticsearch exceptions
     ],
@@ -66,6 +66,6 @@ return [
     'extra' => [
         'host' => env('APP_URL'),
         'php' => PHP_VERSION,
-        'laravel' => app()->version()
-    ]
+        'laravel' => app()->version(),
+    ],
 ];

--- a/src/Handler/ElasticsearchHandler.php
+++ b/src/Handler/ElasticsearchHandler.php
@@ -112,7 +112,6 @@ class ElasticsearchHandler extends AbstractProcessingHandler
                 $params['body'][] = [
                     'index' => [
                         '_index' => $record['_index'],
-                        '_type'  => $record['_type'],
                     ],
                 ];
                 unset($record['_index'], $record['_type']);
@@ -123,6 +122,7 @@ class ElasticsearchHandler extends AbstractProcessingHandler
             $responses = $this->client->bulk($params);
 
             if ($responses['errors'] === true) {
+                // TODO: api has some error, should be return to upper application
                 throw new ElasticsearchRuntimeException('Elasticsearch returned error for one of the records');
             }
         } catch (Throwable $e) {

--- a/src/Providers/LoggerServiceProvider.php
+++ b/src/Providers/LoggerServiceProvider.php
@@ -36,7 +36,16 @@ class LoggerServiceProvider extends ServiceProvider
     {
         $this->app->singleton('betterde.logger', function () {
             $urls = $this->hostsGenerator();
-            $client = ClientBuilder::create()->setHosts($urls)->setRetries(config('logger.elasticsearch.retries'))->build();
+            $client = ClientBuilder::create()->setHosts($urls)->setRetries(config('logger.elasticsearch.retries'));
+
+            $config = head(config('logger.elasticsearch.hosts'));
+
+            if (!empty($config['user'])) {
+                $client->setBasicAuthentication($config['user'], $config['pass']);
+            }
+
+            $client = $client->build();
+
             return new Logger(config('logging.default'), [
                 new ElasticsearchHandler($client, config('logger.options'), config('logger.level'), config('logger.bubble'))
             ]);

--- a/src/Providers/LoggerServiceProvider.php
+++ b/src/Providers/LoggerServiceProvider.php
@@ -35,40 +35,14 @@ class LoggerServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('betterde.logger', function () {
-            $urls = $this->hostsGenerator();
-            $client = ClientBuilder::create()->setHosts($urls)->setRetries(config('logger.elasticsearch.retries'));
-
-            $config = head(config('logger.elasticsearch.hosts'));
-
-            if (!empty($config['user'])) {
-                $client->setBasicAuthentication($config['user'], $config['pass']);
-            }
-
-            $client = $client->build();
+            $client = ClientBuilder::create()
+                ->setHosts(config('logger.elasticsearch.hosts'))
+                ->setRetries(config('logger.elasticsearch.retries'))
+                ->build();
 
             return new Logger(config('logging.default'), [
                 new ElasticsearchHandler($client, config('logger.options'), config('logger.level'), config('logger.bubble'))
             ]);
         });
-    }
-
-    /**
-     * Elasticsearch hosts generator
-     *
-     * Date: 2019/11/24
-     * @return array
-     * @author George
-     */
-    private function hostsGenerator(): array
-    {
-        $urls = [];
-        $hosts = config('logger.elasticsearch.hosts');
-
-        foreach ($hosts as $host) {
-            $certificate = sprintf('%s:%s@', $host['user'], $host['pass']);
-            $urls[] = sprintf('%s::/%s%s:%s', $host['scheme'], $certificate, $host['host'], $host['port']);
-        }
-
-        return $hosts;
     }
 }


### PR DESCRIPTION
fix: 修复 elasticsearch 需要密码认证时，正确配置了认证信息，却无法使用问题
refactor: 移除 bulk 中的 _type 信息
chore: 更新配置文件
chore: 忽略 idea 配置

closed #8 closed #10 closed #11